### PR TITLE
Save image to a png file, print progress and statistics to stdout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.ppm
+*.png
 *.prof
 gorays

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ How to use
 ==========
 
 * go get github.com/kid0m4n/gorays
-* gorays > rays.ppm
-* open rays.ppm (helps to have Gimp installed)
+* gorays
+* open rays.png


### PR DESCRIPTION
Haven't looked at the performance bits as I tend to write code like this directly in assembly anyway, but this pull request contains a few small tweaks to save the image out to a png file, print the progress of the tracing and print timing info directly from inside the application (makes it reasonable to run it via `go run main.go` without then including the compilation time).
