### PR TITLE
Fix bad memory access

### DIFF
--- a/ref/rays.cpp
+++ b/ref/rays.cpp
@@ -176,7 +176,7 @@ int main(int argc, char **argv) {
   std::vector<std::future<void>> wg;
   for(int y=h;y--;) {    //For each row
     wg.push_back(std::async(std::launch::async, [&, y](unsigned int seed) {
-      int k = (h - y) * w * 3;
+      int k = (h - (y+1)) * w * 3;
       for(int x=w;x--;) {   //For each pixel in a line
         //Reuse the vector class to store not XYZ but a RGB pixel color
         vector p(13,13,13);     // Default pixel color is almost pitch black


### PR DESCRIPTION
Fix the problem `k` indicates out of the memory block.
