### PR TITLE
Add C++11 flavor

### DIFF
--- a/cpprays/main.cpp
+++ b/cpprays/main.cpp
@@ -5,6 +5,7 @@
 #include <random>
 #include <thread>
 #include <vector>
+#include <string>
 
 //Define a vector class with constructor and operator: 'v'
 struct vector {


### PR DESCRIPTION
note : `using` is standard C++11 keyword. But MSVC (2012/2013) could not compile this :cry:.
Please use `typedef` if you care about these compilers.
