### PR TITLE
C++ version is also compilable with GCC 4.6

### DIFF
--- a/cpprays/main.cpp
+++ b/cpprays/main.cpp
@@ -83,11 +83,11 @@ private:
 
 #endif
 
-using Objects = std::vector<vector>;
+typedef std::vector<vector> Objects;
 
 Objects objects;
 
-using Art = std::vector<std::string>;
+typedef std::vector<std::string> Art;
 
 Objects makeObjects(const Art& art) {
   Objects o;


### PR DESCRIPTION
My old compiler don't understand this notation. This is also a good solution and works with old compilers. 
