### PR TITLE
Cmd line and output compatibility with go version.

### DIFF
--- a/javarays/Raycaster.java
+++ b/javarays/Raycaster.java
@@ -1,6 +1,7 @@
 package javarays;
 
 import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
 import java.util.Vector;
 
 public final class Raycaster {
@@ -48,30 +49,58 @@ public final class Raycaster {
 
     static float aspectRatio;
 
-    public static void main(final String[] args) throws Exception {
-        final RayVector[] objects = buildObjects();
-        int num_threads = Runtime.getRuntime().availableProcessors();
+    private static float megaPixel;
+    private static int threadCount;
+    private static int renderCount;
 
-        float megaPixel = 1;
-        if(args.length > 0) {
-            megaPixel = Float.parseFloat(args[0]);
-        }
+    /** */
+    static void printUsage() {
+        System.out.println("Usage: [mega pixels] [render count] [threads]");
+        System.out.println("  mega pixels  [  1.0] Size of the image in mega pixel.");
+        System.out.println("  render count [    1] Number of times the image is rendered.");
+        System.out.println("  threads      [#CPUs] Number of threads to render the image.");
+        System.out.println();
+        System.out.println("The result image is stored in render.ppm of the current working directory.");
+    }
 
-        if(args.length > 1) {
-            num_threads = Integer.parseInt(args[1]);
+    /**
+     * Parse passed command line arguments.
+     *
+     * Don't use existing libraries to not create dependencies.
+     */
+    private static void parseArgs(final String[] args) {
+        megaPixel = 1;
+        renderCount = 1;
+        threadCount = Runtime.getRuntime().availableProcessors();
+
+        try {
+            if(args.length > 0) {
+                megaPixel = Float.parseFloat(args[0]);
+            }
+
+            if(args.length > 1) {
+                renderCount = Integer.parseInt(args[1]);
+            }
+
+            if(args.length > 2) {
+                threadCount = Integer.parseInt(args[2]);
+            }
+        } catch(final NumberFormatException e) {
+            System.err.println("Error parsing cmd lines parameter.");
+            System.err.println();
+            printUsage();
+            System.exit(1);
         }
 
         size = (int)(Math.sqrt(megaPixel * 1000000));
         aspectRatio = 512.f / size;
+    }
 
-        final BufferedOutputStream stream = new BufferedOutputStream(System.out);
-        stream.write("".format("P6 %d %d 255 ", size, size).getBytes());
-
-        bytes = new byte[3*size*size];
-
+    /** Represent exactly one render pass */
+    private static void startRenderPass(final RayVector[] objects) throws Exception {
         final Vector<Thread> threads = new Vector<>();
-        for (int i = 0; i < num_threads; ++i) {
-            final Thread thread = new Thread(new Worker(objects, i, num_threads));
+        for (int i = 0; i < threadCount; ++i) {
+            final Thread thread = new Thread(new Worker(objects, i, threadCount));
             thread.start();
             threads.add(thread);
         }
@@ -79,7 +108,29 @@ public final class Raycaster {
         for(final Thread t : threads) {
             t.join();
         }
+    }
 
+    public static void main(final String[] args) throws Exception {
+        parseArgs(args);
+        final RayVector[] objects = buildObjects();
+        bytes = new byte[3*size*size];
+
+        long overallDuration= 0;
+        for(int i = 0; i < renderCount; i++) {
+            System.out.printf("Starting render#%d of size %.2f MP (%dx%d) with %d threads. ",
+                    i+1, megaPixel, size, size, threadCount);
+
+            final long startTime = System.currentTimeMillis();
+            startRenderPass(objects);
+            final long duration = System.currentTimeMillis() - startTime;
+            overallDuration += duration;
+            System.out.printf("Completed in %d ms%n", duration);
+        }
+
+        System.out.printf("Average time for rendering: %d ms%n", (overallDuration / renderCount));
+
+        final BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream("render.ppm"));
+        stream.write("".format("P6 %d %d 255 ", size, size).getBytes());
         stream.write(bytes);
         stream.flush();
     }


### PR DESCRIPTION
This pull request updates the command line options and the output file to mimic the Go version. Also you can have more than one render run in an program invocation

Here is an example:

<pre>
java -Xms4096m -Xmx8192m -XX:+AggressiveOpts javarays/Raycaster 0.05 5
Starting render#1 of size 0.05 MP (223x223) with 8 threads. Completed in 1708 ms
Starting render#2 of size 0.05 MP (223x223) with 8 threads. Completed in 1711 ms
Starting render#3 of size 0.05 MP (223x223) with 8 threads. Completed in 1740 ms
Starting render#4 of size 0.05 MP (223x223) with 8 threads. Completed in 1714 ms
Starting render#5 of size 0.05 MP (223x223) with 8 threads. Completed in 1714 ms
Average time for rendering: 1718 ms
</pre>
  
